### PR TITLE
Feature/chain liveliness

### DIFF
--- a/src/FallbackProvider/FallbackProvider.ts
+++ b/src/FallbackProvider/FallbackProvider.ts
@@ -60,8 +60,8 @@ export type FallbackProviderOptions = {
     /**
      * Interval at which the provider will check the liveliness of the chain and of providers.
      *
-     * Denominated in seconds. If set to 0, the liveliness check will be disabled. If not set, liveliness check will be
-     * disabled.
+     * Denominated in milliseconds. If set to 0, the liveliness check will be disabled. If not set, liveliness check
+     * will be disabled.
      */
     livelinessPollingInterval?: number;
 

--- a/src/FallbackProvider/FallbackProvider.ts
+++ b/src/FallbackProvider/FallbackProvider.ts
@@ -75,7 +75,7 @@ export type FallbackProviderOptions = {
      * @returns A timestamp of when the block (or the latest block) was discovered, in UNIX epoch time. If the block is
      * new, `null` is returned.
      */
-    getBlockDiscoveryTime?: (blockNumber: number) => Promise<number | null> | undefined;
+    getBlockDiscoveryTime?: (blockNumber: number) => Promise<number | null>;
 
     /**
      * A function that allows the provider to set the time at which a block was first discovered. If the function is not
@@ -86,7 +86,7 @@ export type FallbackProviderOptions = {
      * @param currentTime The current time, in UNIX epoch time. If the block is new, this value should be used to set
      * the discovery time. If null, the function should clear the discovery time.
      */
-    setBlockDiscoveryTime?: (blockNumber: number, currentTime: number | null) => Promise<void> | undefined;
+    setBlockDiscoveryTime?: (blockNumber: number, currentTime: number | null) => Promise<void>;
 };
 
 export const DEFAULT_FALLBACK_OPTIONS: FallbackProviderOptions = {
@@ -329,6 +329,10 @@ export class FallbackProvider extends JsonRpcApiProvider {
      * new, `null` is returned.
      */
     private async _getBlockDiscoveryTime(blockNumber: number): Promise<number | null> {
+        if (this.#fallbackOptions.getBlockDiscoveryTime) {
+            return this.#fallbackOptions.getBlockDiscoveryTime(blockNumber);
+        }
+
         const latest = this.#latestBlockDiscovery;
         if (latest.blockNumber === null) {
             return null;
@@ -350,6 +354,10 @@ export class FallbackProvider extends JsonRpcApiProvider {
      * the discovery time. If null, the function should clear the discovery time.
      */
     private async _setBlockDiscoveryTime(blockNumber: number, currentTime: number | null): Promise<void> {
+        if (this.#fallbackOptions.setBlockDiscoveryTime) {
+            return this.#fallbackOptions.setBlockDiscoveryTime(blockNumber, currentTime);
+        }
+
         const latest = this.#latestBlockDiscovery;
         if (currentTime === null) {
             this.#latestBlockDiscovery = {

--- a/src/FallbackProvider/FallbackProvider.ts
+++ b/src/FallbackProvider/FallbackProvider.ts
@@ -15,6 +15,10 @@ export enum FallbackProviderError {
     NO_PROVIDER = "At least one provider must be provided",
     CANNOT_DETECT_NETWORKS = "Could not detect providers networks",
     INCONSISTENT_NETWORKS = "All providers must be connected to the same network",
+    DESTROYED = "Provider has been destroyed",
+    ALL_PROVIDERS_UNAVAILABLE = "All providers are unavailable",
+    HALTED = "Chain has halted",
+    INVALID_FALLBACK_OPTIONS = "Invalid fallback options",
 }
 export const DEFAULT_RETRIES = 0;
 export const DEFAULT_TIMEOUT = 3_000;
@@ -28,9 +32,68 @@ export interface ProviderConfig {
 }
 
 export interface LoggingOptions {
-    debug?: (message: string) => void;
-    warn?: (message: string) => void;
+    debug?: (message: string, metadata?: any) => void;
+    info?: (message: string, metadata?: any) => void;
+    warn?: (message: string, metadata?: any) => void;
+    error?: (message: string, metadata?: any) => void;
 }
+
+export type FallbackProviderOptions = {
+    /**
+     * Maximum block lag allowed for the provider to be considered valid. This is measured by against the median block
+     * number.
+     */
+    allowableBlockLag?: number;
+
+    /**
+     * If the median block number is not updated for this amount of time, the chain is considered halted, and calls will
+     * throw an error.
+     *
+     * Denominated in seconds. If set to 0, the halt detection will be disabled. If not set, the default value will be
+     * used (5 minutes).
+     *
+     * If halt deletection is enabled, ensure that you have a mechanism to handle providers returning incorrect block
+     * numbers, as this can cause the provider to be permanently marked as halted.
+     */
+    haltDetectionTime?: number;
+
+    /**
+     * Interval at which the provider will check the liveliness of the chain and of providers.
+     *
+     * Denominated in seconds. If set to 0, the liveliness check will be disabled. If not set, liveliness check will be
+     * disabled.
+     */
+    livelinessPollingInterval?: number;
+
+    /**
+     * A function that allows the provider to get the time at which a block was first discovered. If the function is not
+     * provided, the provider will use instance variables to get the block discovery time.
+     *
+     * @param blockNumber The block number to check. If the block number is less than the last discovered block number,
+     * the time at which the latest block was discovered is returned.
+     *
+     * @returns A timestamp of when the block (or the latest block) was discovered, in UNIX epoch time. If the block is
+     * new, `null` is returned.
+     */
+    getBlockDiscoveryTime?: (blockNumber: number) => Promise<number | null> | undefined;
+
+    /**
+     * A function that allows the provider to set the time at which a block was first discovered. If the function is not
+     * provided, the provider will use instance variables to store the block discovery time.
+     *
+     * @param blockNumber The block number to set the discovery time for. If the block number is less than the last
+     * discovered block number, the function should not update the discovery time.
+     * @param currentTime The current time, in UNIX epoch time. If the block is new, this value should be used to set
+     * the discovery time. If null, the function should clear the discovery time.
+     */
+    setBlockDiscoveryTime?: (blockNumber: number, currentTime: number | null) => Promise<void> | undefined;
+};
+
+export const DEFAULT_FALLBACK_OPTIONS: FallbackProviderOptions = {
+    allowableBlockLag: 2,
+    haltDetectionTime: 5 * 60, // 5 minutes
+    livelinessPollingInterval: 0, // Disabled
+};
 
 export const filterValidProviders = async (providers: ProviderConfig[]) => {
     if (providers.length === 0) throw new Error(FallbackProviderError.NO_PROVIDER);
@@ -54,22 +117,110 @@ export const filterValidProviders = async (providers: ProviderConfig[]) => {
     return { network: defaultNetwork, providers: availableProviders };
 };
 
+export async function getBlockNumberWithTimeout(provider: JsonRpcApiProvider, timeout = 5000): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error("Timeout"));
+        }, timeout);
+
+        provider
+            .getBlockNumber()
+            .then((blockNumber) => {
+                clearTimeout(timer);
+                resolve(blockNumber);
+            })
+            .catch((error) => {
+                clearTimeout(timer);
+                reject(error);
+            });
+    }).catch((error) => {
+        throw error;
+    });
+}
+
+export const getBlockNumbersAndMedian = async (providers: ProviderConfig[]) => {
+    const blockNumbers = await Promise.all(
+        providers.map(({ provider, timeout }) =>
+            getBlockNumberWithTimeout(provider, timeout ?? DEFAULT_TIMEOUT).catch(() => null)
+        )
+    );
+
+    // Filter out the undefined block numbers.
+    const filteredBlockNumbers = blockNumbers.filter((blockNumber) => blockNumber !== null) as number[];
+    if (filteredBlockNumbers.length === 0) {
+        throw new Error(FallbackProviderError.ALL_PROVIDERS_UNAVAILABLE);
+    }
+
+    // Sort the valid block numbers.
+    const sortedBlockNumbers = filteredBlockNumbers.sort((a, b) => a - b);
+    // Calculate the median, computing the middle value if the length is odd.
+    let median: number;
+    if (sortedBlockNumbers.length % 2 === 0) {
+        const middle = sortedBlockNumbers.length / 2;
+        median = (sortedBlockNumbers[middle - 1] + sortedBlockNumbers[middle]) / 2;
+    } else {
+        median = sortedBlockNumbers[Math.floor(sortedBlockNumbers.length / 2)];
+    }
+
+    // Median should be an integer. Round down if it's not.
+    median = Math.floor(median);
+
+    return { blockNumbers: blockNumbers, median: median };
+};
+
 export class FallbackProvider extends JsonRpcApiProvider {
     #providers: ProviderConfig[];
     #logging: LoggingOptions;
+    #fallbackOptions: FallbackProviderOptions;
+
+    #active = false;
+    #destroyed = false;
+    #halted = false;
+    #activeProviders: ProviderConfig[] = [];
+
+    #latestBlockDiscovery: {
+        blockNumber: number | null;
+        time: number;
+    } = {
+        blockNumber: null,
+        time: 0,
+    };
 
     constructor(
         providers: ProviderConfig[],
         network?: Networkish,
         options?: JsonRpcApiProviderOptions,
-        loggingOptions?: LoggingOptions
+        loggingOptions?: LoggingOptions,
+        fallbackOptions?: FallbackProviderOptions
     ) {
         super(network, options);
 
-        this.#providers = providers;
+        this._validateFallbackOptions(fallbackOptions);
+
+        this.#activeProviders = this.#providers = providers;
         this.#logging = loggingOptions ?? {};
+        this.#fallbackOptions = fallbackOptions ?? {};
 
         this._start();
+    }
+
+    private _validateFallbackOptions(options: FallbackProviderOptions | undefined) {
+        if (!options) {
+            // No options provided. Using the default options.
+            return;
+        }
+
+        if (options.allowableBlockLag !== undefined && options.allowableBlockLag < 0) {
+            throw new Error(FallbackProviderError.INVALID_FALLBACK_OPTIONS);
+        }
+
+        if (options.haltDetectionTime !== undefined && options.haltDetectionTime < 0) {
+            throw new Error(FallbackProviderError.INVALID_FALLBACK_OPTIONS);
+        }
+
+        if (options.livelinessPollingInterval !== undefined && options.livelinessPollingInterval < 0) {
+            throw new Error(FallbackProviderError.INVALID_FALLBACK_OPTIONS);
+        }
     }
 
     private async sendWithProvider(
@@ -150,14 +301,185 @@ export class FallbackProvider extends JsonRpcApiProvider {
     }
 
     async send(method: string, params: { [name: string]: any }): Promise<any> {
-        if (method === "eth_chainId") {
-            return (await filterValidProviders(this.#providers)).network.chainId;
+        if (this.#destroyed) {
+            throw new Error(FallbackProviderError.DESTROYED);
+        }
+        if (this.#halted) {
+            throw new Error(FallbackProviderError.HALTED);
         }
 
-        return this.sendWithProvider(this.#providers, 0, method, params);
+        if (method === "eth_chainId") {
+            return (await filterValidProviders(this.#activeProviders)).network.chainId;
+        }
+
+        return this.sendWithProvider(this.#activeProviders, 0, method, params);
     }
 
     async _send(payload: JsonRpcPayload | Array<JsonRpcPayload>): Promise<Array<JsonRpcResult | JsonRpcError>> {
         throw new Error("Method not implemented.");
+    }
+
+    /**
+     * Gets the time at which a block was first discovered.
+     *
+     * @param blockNumber The block number to check. If the block number is less than the last discovered block number,
+     * the time at which the latest block was discovered is returned.
+     *
+     * @returns A timestamp of when the block (or the latest block) was discovered, in UNIX epoch time. If the block is
+     * new, `null` is returned.
+     */
+    private async _getBlockDiscoveryTime(blockNumber: number): Promise<number | null> {
+        const latest = this.#latestBlockDiscovery;
+        if (latest.blockNumber === null) {
+            return null;
+        }
+
+        if (blockNumber <= latest.blockNumber) {
+            return latest.time;
+        }
+
+        return null;
+    }
+
+    /**
+     * Sets the time at which a block was first discovered.
+     *
+     * @param blockNumber The block number to set the discovery time for. If the block number is less than the last
+     * discovered block number, the function should not update the discovery time.
+     * @param currentTime The current time, in UNIX epoch time. If the block is new, this value should be used to set
+     * the discovery time. If null, the function should clear the discovery time.
+     */
+    private async _setBlockDiscoveryTime(blockNumber: number, currentTime: number | null): Promise<void> {
+        const latest = this.#latestBlockDiscovery;
+        if (currentTime === null) {
+            this.#latestBlockDiscovery = {
+                blockNumber: null,
+                time: 0,
+            };
+
+            return;
+        }
+
+        if (latest.blockNumber !== null) {
+            // We have a latest block to check against.
+            if (blockNumber <= latest.blockNumber) {
+                // We don't update the discovery time if the block is not new.
+                return;
+            }
+        }
+
+        this.#latestBlockDiscovery = {
+            blockNumber: blockNumber,
+            time: currentTime,
+        };
+    }
+
+    private async _livelinessCheck() {
+        const providersToCheck = this.#providers;
+
+        let goodProviders: ProviderConfig[] = [];
+
+        try {
+            // Get the block numbers and the median.
+            const { blockNumbers, median } = await getBlockNumbersAndMedian(providersToCheck);
+
+            // Get the current time, in UNIX epoch time.
+            const currentTime = Math.floor(Date.now() / 1000);
+
+            // Filter the providers that are not too far behind the median.
+            const allowableBlockLag =
+                this.#fallbackOptions.allowableBlockLag ?? DEFAULT_FALLBACK_OPTIONS.allowableBlockLag;
+            const minBlockNumber = median - allowableBlockLag!;
+
+            for (let i = 0; i < blockNumbers.length; i++) {
+                const blockNumber = blockNumbers[i];
+                if (blockNumber === null) {
+                    continue;
+                }
+
+                if (blockNumber >= minBlockNumber) {
+                    goodProviders.push(providersToCheck[i]);
+                }
+            }
+
+            this.#activeProviders = goodProviders;
+
+            // We've filtered the providers by allowable block lag. Now let's check if the chain has halted.
+            const blockDiscoveryTime = await this._getBlockDiscoveryTime(median);
+            if (blockDiscoveryTime === null) {
+                // The block is new. We'll set the block discovery time.
+                await this._setBlockDiscoveryTime(median, currentTime);
+
+                this.#halted = false;
+            } else {
+                // The block is not new. Let's check if the chain has halted.
+                const haltDetectionTime =
+                    this.#fallbackOptions.haltDetectionTime ?? DEFAULT_FALLBACK_OPTIONS.haltDetectionTime;
+
+                if (haltDetectionTime! > 0) {
+                    if (currentTime - blockDiscoveryTime > haltDetectionTime!) {
+                        // The chain has halted.
+                        this.#halted = true;
+                    } else {
+                        this.#halted = false;
+                    }
+                } else {
+                    // Halt detection is disabled.
+                    this.#halted = false;
+                }
+            }
+        } catch (e: any) {
+            this.#logging?.error?.(`[FallbackProvider] Liveliness check failed: ${e.message}`, {
+                error: e,
+            });
+
+            if (e.message === FallbackProviderError.ALL_PROVIDERS_UNAVAILABLE) {
+                this.#activeProviders = [];
+            }
+        }
+    }
+
+    _start(): void {
+        if (this.#destroyed) {
+            throw new Error(FallbackProviderError.DESTROYED);
+        }
+
+        if (!this.#active) {
+            this.#active = true;
+
+            const pollingInterval =
+                this.#fallbackOptions.livelinessPollingInterval ?? DEFAULT_FALLBACK_OPTIONS.livelinessPollingInterval;
+            if (pollingInterval! > 0) {
+                // Liveliness checks are enabled. Start the interval.
+                const intervalId = setInterval(async () => {
+                    if (!this.#active) {
+                        clearInterval(intervalId); // Stop the interval if #active is false
+
+                        return;
+                    }
+
+                    await this._livelinessCheck(); // Call the async function
+                }, pollingInterval);
+            }
+        }
+
+        super._start();
+    }
+
+    destroy(): void {
+        this.#destroyed = true;
+        this.#active = false;
+        super.destroy();
+
+        // Try and destory all providers.
+        this.#providers.forEach(({ provider }) => {
+            try {
+                provider.destroy();
+            } catch (e: any) {
+                this.#logging?.error?.(`[FallbackProvider] Error destroying provider: ${e.message}`, {
+                    error: e,
+                });
+            }
+        });
     }
 }

--- a/src/FallbackProvider/FallbackProvider.ts
+++ b/src/FallbackProvider/FallbackProvider.ts
@@ -204,6 +204,14 @@ export class FallbackProvider extends JsonRpcApiProvider {
         this._start();
     }
 
+    public activeProvidersCount(): number {
+        return this.#activeProviders.length;
+    }
+
+    public isHalted(): boolean {
+        return this.#halted;
+    }
+
     private _validateFallbackOptions(options: FallbackProviderOptions | undefined) {
         if (!options) {
             // No options provided. Using the default options.

--- a/test/FallbackProvider/FallbackProvider.test.ts
+++ b/test/FallbackProvider/FallbackProvider.test.ts
@@ -46,76 +46,84 @@ describe("FallbackProvider", () => {
     });
 
     describe("perform", () => {
+        let provider: FallbackProvider;
+
+        afterEach(() => {
+            if (provider) {
+                provider.destroy();
+            }
+        });
+
         it("should return the first value if the first provider is successful", async () => {
             const provider1 = new MockProvider("1");
             const provider2 = new MockProvider("2");
-            const provider = new FallbackProvider([provider1, provider2]);
+            provider = new FallbackProvider([provider1, provider2]);
 
-            jest.spyOn(provider1, "send");
-            jest.spyOn(provider2, "send");
+            jest.spyOn(provider1, "sendNonBlockNumberCall");
+            jest.spyOn(provider2, "sendNonBlockNumberCall");
 
             const res = await provider.send("send", {});
 
-            expect(provider1.send).toHaveBeenCalledTimes(1);
-            expect(provider2.send).not.toHaveBeenCalled();
+            expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
+            expect(provider2.sendNonBlockNumberCall).not.toHaveBeenCalled();
             expect(res).toEqual("1");
         });
 
         it("should return the second value if the first provider is failing", async () => {
             const provider1 = new FailingProvider("1");
             const provider2 = new MockProvider("2");
-            const provider = new FallbackProvider([provider1, provider2]);
+            provider = new FallbackProvider([provider1, provider2]);
 
-            jest.spyOn(provider1, "send");
-            jest.spyOn(provider2, "send");
+            jest.spyOn(provider1, "sendNonBlockNumberCall");
+            jest.spyOn(provider2, "sendNonBlockNumberCall");
 
             const res = await provider.send("send", {});
 
-            expect(provider1.send).toHaveBeenCalledTimes(1);
-            expect(provider2.send).toHaveBeenCalledTimes(1);
+            expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
+            expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
             expect(res).toEqual("2");
         });
 
         it("should fail if all providers are failing", async () => {
             const provider1 = new FailingProvider("1");
             const provider2 = new FailingProvider("2");
-            const provider = new FallbackProvider([provider1, provider2]);
+            provider = new FallbackProvider([provider1, provider2]);
 
-            jest.spyOn(provider1, "send");
-            jest.spyOn(provider2, "send");
+            jest.spyOn(provider1, "sendNonBlockNumberCall");
+            jest.spyOn(provider2, "sendNonBlockNumberCall");
 
             await expect(provider.send("send", {})).rejects.toThrowError("Failing provider used: 2");
 
-            expect(provider1.send).toHaveBeenCalledTimes(1);
-            expect(provider2.send).toHaveBeenCalledTimes(1);
+            expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
+            expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
         });
 
         it("should retry the first provider", async () => {
             const provider1 = new FailingProvider("1", 1);
             const provider2 = new FailingProvider("2");
-            const provider = new FallbackProvider([{ provider: provider1, retries: 1 }, provider2]);
+            provider = new FallbackProvider([{ provider: provider1, retries: 1 }, provider2]);
 
-            jest.spyOn(provider1, "send");
-            jest.spyOn(provider2, "send");
+            jest.spyOn(provider1, "sendNonBlockNumberCall");
+            jest.spyOn(provider2, "sendNonBlockNumberCall");
 
             const res = await provider.send("send", {});
 
-            expect(provider1.send).toHaveBeenCalledTimes(2);
-            expect(provider2.send).not.toHaveBeenCalled();
+            expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(2);
+            expect(provider2.sendNonBlockNumberCall).not.toHaveBeenCalled();
             expect(res).toEqual("1");
         });
         it("should fallback after max retries reached", async () => {
             const provider1 = new FailingProvider("1", 2);
             const provider2 = new MockProvider("2");
-            const provider = new FallbackProvider([{ provider: provider1, retries: 1 }, provider2]);
+            provider = new FallbackProvider([{ provider: provider1, retries: 1 }, provider2]);
 
-            jest.spyOn(provider1, "send");
-            jest.spyOn(provider2, "send");
+            jest.spyOn(provider1, "sendNonBlockNumberCall");
+            jest.spyOn(provider2, "sendNonBlockNumberCall");
 
             const res = await provider.send("send", {});
 
-            expect(provider1.send).toHaveBeenCalledTimes(2);
-            expect(provider2.send).toHaveBeenCalledTimes(1);
+            expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(2);
+            expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
             expect(res).toEqual("2");
         });
 
@@ -123,81 +131,81 @@ describe("FallbackProvider", () => {
             it("should fallback if the websocket is closing", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new MockProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 provider1.setWsReadyState(2);
 
                 const res = await provider.send("send", {});
 
-                expect(provider1.send).not.toHaveBeenCalled();
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).not.toHaveBeenCalled();
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
                 expect(res).toEqual("2");
             });
 
             it("should fallback if the websocket is closed", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new MockProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 provider1.setWsReadyState(3);
 
                 const res = await provider.send("send", {});
 
-                expect(provider1.send).not.toHaveBeenCalled();
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).not.toHaveBeenCalled();
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
                 expect(res).toEqual("2");
             });
 
             it("should fallback if the websocket is not ready", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new MockProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 provider1.setWsReadyState(0);
 
                 const res = await provider.send("send", {});
 
-                expect(provider1.send).not.toHaveBeenCalled();
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).not.toHaveBeenCalled();
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
                 expect(res).toEqual("2");
             });
 
             it("should not fallback if the websocket is ready", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new MockProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 provider1.setWsReadyState(1);
 
                 const res = await provider.send("send", {});
 
-                expect(provider1.send).toHaveBeenCalledTimes(1);
-                expect(provider2.send).not.toHaveBeenCalled();
+                expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
+                expect(provider2.sendNonBlockNumberCall).not.toHaveBeenCalled();
                 expect(res).toEqual("1");
             });
 
             it("should fallback if the websocket is connecting but then proceed with the ws provider when the fallback fails", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new FailingProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 // When send is called on provider2, make provider1 ready.
-                jest.spyOn(provider2, "send").mockImplementationOnce(() => {
+                jest.spyOn(provider2, "sendNonBlockNumberCall").mockImplementationOnce(() => {
                     provider1.setWsReadyState(1);
                     return Promise.reject(new Error("Failed to send"));
                 });
@@ -206,74 +214,74 @@ describe("FallbackProvider", () => {
 
                 const res = await provider.send("send", {});
 
-                expect(provider1.send).toHaveBeenCalledTimes(1);
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
                 expect(res).toEqual("1");
             });
 
             it("should fallback if the websocket is closing, then fail when the fallback fails", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new FailingProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
                 provider1.setWsReadyState(2);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 await expect(provider.send("send", {})).rejects.toThrowError("Failing provider used: 2");
 
-                expect(provider1.send).toHaveBeenCalledTimes(0); // Doesn't try sending since the ws is closing
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(0); // Doesn't try sending since the ws is closing
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
             });
 
             it("should fallback if the websocket is closed, then fail when the fallback fails", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new FailingProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
                 provider1.setWsReadyState(3);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 await expect(provider.send("send", {})).rejects.toThrowError("Failing provider used: 2");
 
-                expect(provider1.send).not.toHaveBeenCalled(); // Doesn't try sending since the ws is closing
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).not.toHaveBeenCalled(); // Doesn't try sending since the ws is closing
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
             });
 
             it("should fallback if the websocket is forever connecting", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new MockProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 provider1.setWsReadyState(0);
 
                 const res = await provider.send("send", {});
 
-                expect(provider1.send).not.toHaveBeenCalled(); // Doesn't try sending since the ws never connects and we fallback
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).not.toHaveBeenCalled(); // Doesn't try sending since the ws never connects and we fallback
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
                 expect(res).toEqual("2");
             });
 
             it("should fallback if the websocket is forever connecting, then proceed with the ws provider when the fallback fails, eventually failing", async () => {
                 const provider1 = new MockWebsocketProvider("1");
                 const provider2 = new FailingProvider("2");
-                const provider = new FallbackProvider([provider1, provider2]);
+                provider = new FallbackProvider([provider1, provider2]);
 
-                jest.spyOn(provider1, "send");
-                jest.spyOn(provider2, "send");
+                jest.spyOn(provider1, "sendNonBlockNumberCall");
+                jest.spyOn(provider2, "sendNonBlockNumberCall");
 
                 provider1.setWsReadyState(0);
 
                 await expect(provider.send("send", {})).rejects.toThrowError("timeout exceeded");
 
-                expect(provider1.send).toHaveBeenCalledTimes(1);
-                expect(provider2.send).toHaveBeenCalledTimes(1);
+                expect(provider1.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
+                expect(provider2.sendNonBlockNumberCall).toHaveBeenCalledTimes(1);
             });
         });
     });

--- a/test/FallbackProvider/FallbackProvider.test.ts
+++ b/test/FallbackProvider/FallbackProvider.test.ts
@@ -180,6 +180,24 @@ describe("FallbackProvider", () => {
             expect(provider2.send).toHaveBeenCalledTimes(1);
             expect(provider3.send).toHaveBeenCalledTimes(1);
         });
+
+        it("should return an integer median, rounding down", async () => {
+            const underlyingBlockNumbers = [101, 102];
+
+            const provider1 = new MockProvider("1", 1, underlyingBlockNumbers[0] as number);
+            const provider2 = new MockProvider("1", 1, underlyingBlockNumbers[1] as number);
+
+            jest.spyOn(provider1, "send");
+            jest.spyOn(provider2, "send");
+
+            const { blockNumbers, median } = await getBlockNumbersAndMedian([provider1, provider2]);
+
+            expect(blockNumbers).toEqual(underlyingBlockNumbers);
+            expect(median).toEqual(101);
+
+            expect(provider1.send).toHaveBeenCalledTimes(1);
+            expect(provider2.send).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("perform", () => {

--- a/test/FallbackProvider/helpers/FailingProvider.ts
+++ b/test/FallbackProvider/helpers/FailingProvider.ts
@@ -2,15 +2,26 @@ import MockProvider from "./MockProvider";
 
 export default class FailingProvider extends MockProvider {
     failureCount = 0;
-    constructor(_id: string, protected _numberOfFailures = 100) {
+
+    constructor(_id: string, protected _numberOfFailures = 100, protected _blockNumber = 1) {
         super(_id);
     }
-    async send(): Promise<string> {
+
+    async sendNonBlockNumberCall(method: string, params: { [name: string]: any }): Promise<any> {
         this.failureCount++;
         if (this.failureCount > this._numberOfFailures) {
             this.failureCount = 0;
             return this._id;
         }
+
         throw Error("Failing provider used: " + this._id);
+    }
+
+    async send(method: string, params: { [name: string]: any }): Promise<any> {
+        if (method === "eth_blockNumber") {
+            return this._blockNumber;
+        }
+
+        return await this.sendNonBlockNumberCall(method, params);
     }
 }

--- a/test/FallbackProvider/helpers/FailingProvider.ts
+++ b/test/FallbackProvider/helpers/FailingProvider.ts
@@ -11,6 +11,11 @@ export default class FailingProvider extends MockProvider {
         this.failureCount++;
         if (this.failureCount > this._numberOfFailures) {
             this.failureCount = 0;
+
+            if (method === "eth_blockNumber") {
+                return this._blockNumber;
+            }
+
             return this._id;
         }
 
@@ -18,10 +23,6 @@ export default class FailingProvider extends MockProvider {
     }
 
     async send(method: string, params: { [name: string]: any }): Promise<any> {
-        if (method === "eth_blockNumber") {
-            return this._blockNumber;
-        }
-
         return await this.sendNonBlockNumberCall(method, params);
     }
 }

--- a/test/FallbackProvider/helpers/MockProvider.ts
+++ b/test/FallbackProvider/helpers/MockProvider.ts
@@ -1,7 +1,7 @@
 import { JsonRpcApiProvider, JsonRpcError, JsonRpcPayload, JsonRpcResult, Network } from "ethers";
 
 export default class MockProvider extends JsonRpcApiProvider {
-    constructor(protected _id: string, protected _networkId = 1) {
+    constructor(protected _id: string, protected _networkId = 1, protected _blockNumber = 1) {
         super(_networkId);
     }
 
@@ -14,10 +14,18 @@ export default class MockProvider extends JsonRpcApiProvider {
         });
     }
 
+    async sendNonBlockNumberCall(method: string, params: { [name: string]: any }): Promise<any> {
+        return this._id;
+    }
+
     async send(method: string, params: { [name: string]: any }): Promise<any> {
         this._start();
 
-        return this._id;
+        if (method === "eth_blockNumber") {
+            return this._blockNumber;
+        }
+
+        return await this.sendNonBlockNumberCall(method, params);
     }
 
     async _send(payload: JsonRpcPayload | Array<JsonRpcPayload>): Promise<Array<JsonRpcResult | JsonRpcError>> {

--- a/test/FallbackProvider/helpers/MockWebsocketProvider.ts
+++ b/test/FallbackProvider/helpers/MockWebsocketProvider.ts
@@ -5,7 +5,7 @@ import { default as MockWebsocket } from "./MockWebsocket";
 export default class MockWebsocketProvider extends MockProvider {
     protected _websocket = new MockWebsocket();
 
-    constructor(_id: string, _networkId = 1) {
+    constructor(_id: string, _networkId = 1, protected _blockNumber = 1) {
         super(_id, _networkId);
     }
 
@@ -17,7 +17,7 @@ export default class MockWebsocketProvider extends MockProvider {
         return this._websocket;
     }
 
-    async send() {
+    async sendNonBlockNumberCall(method: string, params: { [name: string]: any }): Promise<any> {
         const state = this._websocket.readyState;
 
         if (state == 0) {
@@ -41,5 +41,15 @@ export default class MockWebsocketProvider extends MockProvider {
         } else {
             throw new Error("Websocket is not ready");
         }
+    }
+
+    async send(method: string, params: { [name: string]: any }): Promise<any> {
+        this._start();
+
+        if (method === "eth_blockNumber") {
+            return this._blockNumber;
+        }
+
+        return await this.sendNonBlockNumberCall(method, params);
     }
 }

--- a/test/FallbackProvider/helpers/RecoveringProvider.ts
+++ b/test/FallbackProvider/helpers/RecoveringProvider.ts
@@ -1,7 +1,9 @@
 import { JsonRpcApiProvider, JsonRpcError, JsonRpcPayload, JsonRpcResult, Network } from "ethers";
 
-export default class MockProvider extends JsonRpcApiProvider {
-    constructor(protected _id: string, protected _networkId = 1, public blockNumber = 1) {
+export default class RecoveringProvider extends JsonRpcApiProvider {
+    failing = true;
+
+    constructor(protected _id: string, protected _networkId = 1, protected _blockNumber = 1) {
         super(_networkId);
     }
 
@@ -21,8 +23,12 @@ export default class MockProvider extends JsonRpcApiProvider {
     async send(method: string, params: { [name: string]: any }): Promise<any> {
         this._start();
 
+        if (this.failing) {
+            throw new Error("Failing provider used: " + this._id);
+        }
+
         if (method === "eth_blockNumber") {
-            return this.blockNumber;
+            return this._blockNumber;
         }
 
         return await this.sendNonBlockNumberCall(method, params);

--- a/test/FallbackProvider/helpers/StallingProvider.ts
+++ b/test/FallbackProvider/helpers/StallingProvider.ts
@@ -1,0 +1,25 @@
+import { promiseWithTimeout } from "../../../src/utils/promises";
+import { default as MockProvider } from "./MockProvider";
+
+export default class StallingProvider extends MockProvider {
+    constructor(_id: string, _networkId = 1, protected _blockNumber = 1) {
+        super(_id, _networkId);
+    }
+
+    async send(method: string, params: { [name: string]: any }): Promise<any> {
+        this._start();
+
+        // Wait until the readyState is 1, timeout after 10 seconds
+        const startTime = Date.now();
+        const timeout = 10000;
+        const promise = new Promise((resolve, reject) => {
+            const interval = setInterval(() => {
+                if (Date.now() - startTime > timeout + 1000) {
+                    clearInterval(interval);
+                    reject("Timeout");
+                }
+            }, 10);
+        }) as Promise<string>;
+        return await promiseWithTimeout(promise, timeout);
+    }
+}


### PR DESCRIPTION
- Adds a mechanism to continually filter out failing providers
- Adds a mechanism to continually filter out lagging providers (by block number)
- Adds a mechanism to detect a halted chain and have calls throw an error